### PR TITLE
ML-435 Specific name for incrementer and added better CORS detection

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -31,6 +31,10 @@ exports.register = (server, options) => {
 
         if (request._route === specials.notFound.route) {
             routePath = '/{notFound*}';
+        } else if (specials.options && request._route === specials.options.route) {
+            routePath = '/{cors*}';
+        } else if (request._route.path === '/' && request._route.method === 'options') {
+            routePath = '/{cors*}';
         }
 
         const startDate = new Date(request.info.received);
@@ -56,7 +60,7 @@ exports.register = (server, options) => {
 
         Hoek.merge(tags, stateTags);
 
-        dogstatsdClient.incr(statName, null, tags);
+        dogstatsdClient.incr(`${statName}.hits`, null, tags);
         dogstatsdClient.gauge(`${statName}.response_time`, ms, tags);
         dogstatsdClient.timer(statName, ms, tags);
 

--- a/spec/hapi-dogstatsd.spec.js
+++ b/spec/hapi-dogstatsd.spec.js
@@ -50,7 +50,7 @@ describe('lib-hapi-dogstatsd plugin tests', () => {
         it('should report stats for root path', async () => {
             const tags = ['url_path:/', 'route_path:/', 'status_code:200', 'http_method:GET'];
             await server.inject('/');
-            expect(mockStatsdClient.incr).toHaveBeenCalledWith('route', null, tags);
+            expect(mockStatsdClient.incr).toHaveBeenCalledWith('route.hits', null, tags);
             expect(mockStatsdClient.gauge).toHaveBeenCalledWith('route.response_time', jasmine.any(Number), tags);
             expect(mockStatsdClient.timer).toHaveBeenCalledWith('route', jasmine.any(Number), tags);
         });
@@ -58,7 +58,7 @@ describe('lib-hapi-dogstatsd plugin tests', () => {
         it('should report stats with path name set explicitly', async () => {
             const tags = ['url_path:/test/path', 'route_path:/test/{param}', 'status_code:200', 'http_method:GET'];
             await server.inject('/test/path');
-            expect(mockStatsdClient.incr).toHaveBeenCalledWith('route', null, tags);
+            expect(mockStatsdClient.incr).toHaveBeenCalledWith('route.hits', null, tags);
             expect(mockStatsdClient.gauge).toHaveBeenCalledWith('route.response_time', jasmine.any(Number), tags);
             expect(mockStatsdClient.timer).toHaveBeenCalledWith('route', jasmine.any(Number), tags);
         });
@@ -66,7 +66,7 @@ describe('lib-hapi-dogstatsd plugin tests', () => {
         it('should report stats with merging tags from route', async () => {
             const tags = ['url_path:/test/withtags', 'route_path:/test/withtags', 'status_code:200', 'http_method:GET', 'tag1:true', 'tag2:false'];
             await server.inject('/test/withtags');
-            expect(mockStatsdClient.incr).toHaveBeenCalledWith('route', null, tags);
+            expect(mockStatsdClient.incr).toHaveBeenCalledWith('route.hits', null, tags);
             expect(mockStatsdClient.gauge).toHaveBeenCalledWith('route.response_time', jasmine.any(Number), tags);
             expect(mockStatsdClient.timer).toHaveBeenCalledWith('route', jasmine.any(Number), tags);
         });
@@ -74,13 +74,13 @@ describe('lib-hapi-dogstatsd plugin tests', () => {
         it('should report proper HTTP status', async () => {
             const tags = ['url_path:/notFound', 'route_path:/{notFound*}', 'status_code:404', 'http_method:GET'];
             await server.inject('/notFound');
-            expect(mockStatsdClient.incr).toHaveBeenCalledWith('route', null, tags);
+            expect(mockStatsdClient.incr).toHaveBeenCalledWith('route.hits', null, tags);
             expect(mockStatsdClient.gauge).toHaveBeenCalledWith('route.response_time', jasmine.any(Number), tags);
             expect(mockStatsdClient.timer).toHaveBeenCalledWith('route', jasmine.any(Number), tags);
         });
 
         it('should report report the proper HTTP method', async () => {
-            const tags = ['url_path:/', 'route_path:/', 'status_code:200', 'http_method:OPTIONS'];
+            const tags = ['url_path:/', 'route_path:/{cors*}', 'status_code:200', 'http_method:OPTIONS'];
             await server.inject({
                 method: 'OPTIONS',
                 headers: {
@@ -88,7 +88,7 @@ describe('lib-hapi-dogstatsd plugin tests', () => {
                 },
                 url: '/'
             });
-            expect(mockStatsdClient.incr).toHaveBeenCalledWith('route', null, tags);
+            expect(mockStatsdClient.incr).toHaveBeenCalledWith('route.hits', null, tags);
             expect(mockStatsdClient.gauge).toHaveBeenCalledWith('route.response_time', jasmine.any(Number), tags);
             expect(mockStatsdClient.timer).toHaveBeenCalledWith('route', jasmine.any(Number), tags);
         });
@@ -97,7 +97,7 @@ describe('lib-hapi-dogstatsd plugin tests', () => {
             const tags = ['url_path:/throwError', 'route_path:/throwError', 'status_code:500', 'http_method:GET'];
             const res = await server.inject('/throwError');
             expect(res.statusCode).toBe(500);
-            expect(mockStatsdClient.incr).toHaveBeenCalledWith('route', null, tags);
+            expect(mockStatsdClient.incr).toHaveBeenCalledWith('route.hits', null, tags);
             expect(mockStatsdClient.gauge).toHaveBeenCalledWith('route.response_time', jasmine.any(Number), tags);
             expect(mockStatsdClient.timer).toHaveBeenCalledWith('route', jasmine.any(Number), tags);
         });


### PR DESCRIPTION
Resolve an issue where the stats were being reported multiple times. The root cause was that the `incr` and `timer` calls were using the same metric name. Breaking out the `incr` call to `${statName}.route.hits` should resolve the issue.

Also, updated CORS detection to clean up the reported metrics.