### PR TITLE
Add codecov reporting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,14 @@ jobs:
       # Run Tests!
       - run: npm test
 
+      # Upload to CodeCov
+      - run:
+          name: 'Upload to codecov.io'
+          command: bash <(curl -s https://codecov.io/bash) -t eddcd9b9-d6a1-4dfc-8a08-4115702686d6
+
+      - store_artifacts:
+          path: ./coverage
+
 workflows:
   version: 2
   build_workflow:


### PR DESCRIPTION
Add codecov reporting (free for public repos) https://codecov.io/gh/GoodwayGroup/lib-hapi-dogstatsd