### PR TITLE
ML-644 Add dns tag to all metrics

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,6 +23,7 @@ exports.register = (server, options) => {
 
     server.ext('onPreResponse', (request, h) => {
         const specials = request._core.router.specials;
+        const requestDns = request.headers.host.replace(/:/, '_');
         const urlPath = request.url.pathname;
         let routePath = request.route.path;
         if (settings.excludedPaths.indexOf(urlPath) !== -1) {
@@ -47,6 +48,7 @@ exports.register = (server, options) => {
         const statName = 'route';
 
         const tags = [
+            `dns:${requestDns}`,
             `url_path:${urlPath}`,
             `route_path:${routePath}`,
             `status_code:${statusCode}`,

--- a/spec/hapi-dogstatsd.spec.js
+++ b/spec/hapi-dogstatsd.spec.js
@@ -48,7 +48,7 @@ describe('lib-hapi-dogstatsd plugin tests', () => {
         });
 
         it('should report stats for root path', async () => {
-            const tags = ['url_path:/', 'route_path:/', 'status_code:200', 'http_method:GET'];
+            const tags = ['dns:localhost_8085', 'url_path:/', 'route_path:/', 'status_code:200', 'http_method:GET'];
             await server.inject('/');
             expect(mockStatsdClient.incr).toHaveBeenCalledWith('route.hits', null, tags);
             expect(mockStatsdClient.gauge).toHaveBeenCalledWith('route.response_time', jasmine.any(Number), tags);
@@ -56,7 +56,7 @@ describe('lib-hapi-dogstatsd plugin tests', () => {
         });
 
         it('should report stats with path name set explicitly', async () => {
-            const tags = ['url_path:/test/path', 'route_path:/test/{param}', 'status_code:200', 'http_method:GET'];
+            const tags = ['dns:localhost_8085', 'url_path:/test/path', 'route_path:/test/{param}', 'status_code:200', 'http_method:GET'];
             await server.inject('/test/path');
             expect(mockStatsdClient.incr).toHaveBeenCalledWith('route.hits', null, tags);
             expect(mockStatsdClient.gauge).toHaveBeenCalledWith('route.response_time', jasmine.any(Number), tags);
@@ -64,7 +64,7 @@ describe('lib-hapi-dogstatsd plugin tests', () => {
         });
 
         it('should report stats with merging tags from route', async () => {
-            const tags = ['url_path:/test/withtags', 'route_path:/test/withtags', 'status_code:200', 'http_method:GET', 'tag1:true', 'tag2:false'];
+            const tags = ['dns:localhost_8085', 'url_path:/test/withtags', 'route_path:/test/withtags', 'status_code:200', 'http_method:GET', 'tag1:true', 'tag2:false'];
             await server.inject('/test/withtags');
             expect(mockStatsdClient.incr).toHaveBeenCalledWith('route.hits', null, tags);
             expect(mockStatsdClient.gauge).toHaveBeenCalledWith('route.response_time', jasmine.any(Number), tags);
@@ -72,7 +72,7 @@ describe('lib-hapi-dogstatsd plugin tests', () => {
         });
 
         it('should report proper HTTP status', async () => {
-            const tags = ['url_path:/notFound', 'route_path:/{notFound*}', 'status_code:404', 'http_method:GET'];
+            const tags = ['dns:localhost_8085', 'url_path:/notFound', 'route_path:/{notFound*}', 'status_code:404', 'http_method:GET'];
             await server.inject('/notFound');
             expect(mockStatsdClient.incr).toHaveBeenCalledWith('route.hits', null, tags);
             expect(mockStatsdClient.gauge).toHaveBeenCalledWith('route.response_time', jasmine.any(Number), tags);
@@ -80,7 +80,7 @@ describe('lib-hapi-dogstatsd plugin tests', () => {
         });
 
         it('should report report the proper HTTP method', async () => {
-            const tags = ['url_path:/', 'route_path:/{cors*}', 'status_code:200', 'http_method:OPTIONS'];
+            const tags = ['dns:localhost_8085', 'url_path:/', 'route_path:/{cors*}', 'status_code:200', 'http_method:OPTIONS'];
             await server.inject({
                 method: 'OPTIONS',
                 headers: {
@@ -94,7 +94,7 @@ describe('lib-hapi-dogstatsd plugin tests', () => {
         });
 
         it('should not change the status code of a response', async () => {
-            const tags = ['url_path:/throwError', 'route_path:/throwError', 'status_code:500', 'http_method:GET'];
+            const tags = ['dns:localhost_8085', 'url_path:/throwError', 'route_path:/throwError', 'status_code:500', 'http_method:GET'];
             const res = await server.inject('/throwError');
             expect(res.statusCode).toBe(500);
             expect(mockStatsdClient.incr).toHaveBeenCalledWith('route.hits', null, tags);


### PR DESCRIPTION
Adds `dns:<host header>` tag to all metrics. This will allow tracking of the `request.headers.host` value within datadog metrics. This will also replace `:` with `_` in the tag value for `dns`.