### PR TITLE
ML-1182 Allow exclusion of default tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ if (process.env.DOGSTATSD_HOST && process.env.NODE_ENV !== 'test') {
     - default: ```[`env:${process.env.NODE_ENV || 'development'}`]```
 - `excludedPaths`: An array of URL paths to ignore sending metrics for.
     - default: `['/favicon.ico', '/health-check']`
+- `excludedTags`: An array of tag keys that will be excluded from the default list of tags added to each metric. The default list of tags is: `dns, url_path, route_path, status_code, http_method`
+    - default: `[]`
 
 ### Route Based Tags
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,11 +7,45 @@ const defaults = {
     port: 8125,
     tags: [`env:${process.env.NODE_ENV || 'development'}`],
     prefix: 'hapi',
-    excludedPaths: ['/favicon.ico', '/health-check']
+    excludedPaths: ['/favicon.ico', '/health-check'],
+    excludedTags: []
+};
+
+const getRequestDns = request => request.headers.host.replace(/:/, '_');
+
+const getUrlPath = request => request.url.pathname;
+
+const getRoutePath = (request) => {
+    const specials = request._core.router.specials;
+
+    if (request._route === specials.notFound.route) {
+        return '/{notFound*}';
+    } else if (specials.options && request._route === specials.options.route) {
+        return '/{cors*}';
+    } else if (request._route.path === '/' && request._route.method === 'options') {
+        return '/{cors*}';
+    }
+    return request.route.path;
+};
+
+const getStatusCode = request => ((request.response.isBoom)
+    ? request.response.output.statusCode : request.response.statusCode);
+
+const getHttpMethod = request => request.method.toUpperCase();
+
+const tagMap = {
+    dns: getRequestDns,
+    url_path: getUrlPath,
+    route_path: getRoutePath,
+    status_code: getStatusCode,
+    http_method: getHttpMethod
 };
 
 exports.register = (server, options) => {
     const settings = Hoek.applyToDefaults(defaults, options || {});
+    // Filter list of default tags, removing excludedTags
+    settings.defaultTags = Object.keys(tagMap).filter(e => !settings.excludedTags.includes(e));
+
     const dogstatsdClient = options.dogstatsdClient || new DogstatsdClient({
         host: settings.host,
         port: settings.port,
@@ -22,38 +56,18 @@ exports.register = (server, options) => {
     server.decorate('server', 'dogstatsd', dogstatsdClient);
 
     server.ext('onPreResponse', (request, h) => {
-        const specials = request._core.router.specials;
-        const requestDns = request.headers.host.replace(/:/, '_');
-        const urlPath = request.url.pathname;
-        let routePath = request.route.path;
-        if (settings.excludedPaths.indexOf(urlPath) !== -1) {
+        if (settings.excludedPaths.indexOf(request.url.pathname) !== -1) {
             return h.continue;
-        }
-
-        if (request._route === specials.notFound.route) {
-            routePath = '/{notFound*}';
-        } else if (specials.options && request._route === specials.options.route) {
-            routePath = '/{cors*}';
-        } else if (request._route.path === '/' && request._route.method === 'options') {
-            routePath = '/{cors*}';
         }
 
         const startDate = new Date(request.info.received);
         const endDate = new Date();
         const ms = endDate - startDate;
 
-        const statusCode = (request.response.isBoom)
-            ? request.response.output.statusCode : request.response.statusCode;
-
-        const statName = 'route';
-
-        const tags = [
-            `dns:${requestDns}`,
-            `url_path:${urlPath}`,
-            `route_path:${routePath}`,
-            `status_code:${statusCode}`,
-            `http_method:${request.method.toUpperCase()}`
-        ];
+        const tags = settings.defaultTags.reduce((prev, tag) => {
+            prev.push(`${tag}:${tagMap[tag](request)}`);
+            return prev;
+        }, []);
 
         let stateTags = [];
         if (request.plugins.dogstatsd) {
@@ -62,9 +76,9 @@ exports.register = (server, options) => {
 
         Hoek.merge(tags, stateTags);
 
-        dogstatsdClient.incr(`${statName}.hits`, null, tags);
-        dogstatsdClient.gauge(`${statName}.response_time`, ms, tags);
-        dogstatsdClient.timer(statName, ms, tags);
+        dogstatsdClient.incr('route.hits', null, tags);
+        dogstatsdClient.gauge('route.response_time', ms, tags);
+        dogstatsdClient.timer('route', ms, tags);
 
         return h.continue;
     });


### PR DESCRIPTION
Adds the ability to exclude default tags from the metrics that are pushed by the service. For example, if you wanted to stop tagging all metrics with `url_path` you could use the following config:

```js
await server.register({
    plugin: HapiDogstatsd,
    options: {
        host: process.env.DOGSTATSD_HOST,
        port: process.env.DOGSTATSD_PORT || 8125,
        tags: [`env:${process.env.NODE_ENV || 'development'}`],
        prefix: 'neato-service',
        excludedTags: ['url_path']
    }
});
```

This would result in a tag list of:

```js
[
    'end:production',
    'dns:github.com',
    'route_path:/api/v1/user/{id}/edit',
    'status_code:200',
    'http_method:POST'
]
```