### PR TITLE
ML-1165 Add support for passing extra metrics specific to a route

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,26 @@ To add custom tags specific to a route, use the [response.plugin](https://github
 response.plugins['dogstatsd'] = { tags: ['custom:tag', 'key:value'] }
 ```
 
+### Route Based Metrics
+
+To add custom metrics specific to a route, use the [response.plugin](https://github.com/hapijs/hapi/blob/master/API.md#response.plugins) state block to pass `metrics` to the plugin. These metrics will be merged with the default metrics that are generated.
+
+The `metrics` will need to have the following structure.
+
+```js
+response.plugins.dogstatsd.metrics = [{
+    type: 'gauge',
+    name: 'cache.orphans',
+    value: 123,
+    tags: [`cache_db:${cache}`]
+}, {
+    type: 'incr',
+    name: 'cache.hit',
+    value: null,
+    tags: [`cache_db:${cache}`]
+}]
+```
+
 ### Default Tags
 
 These tags are set on every request:

--- a/lib/index.js
+++ b/lib/index.js
@@ -64,21 +64,42 @@ exports.register = (server, options) => {
         const endDate = new Date();
         const ms = endDate - startDate;
 
-        const tags = settings.defaultTags.reduce((prev, tag) => {
+        const localTags = settings.defaultTags.reduce((prev, tag) => {
             prev.push(`${tag}:${tagMap[tag](request)}`);
             return prev;
         }, []);
 
+        const defaultMetrics = [{
+            type: 'incr',
+            name: 'route.hits',
+            value: null,
+            localTags
+        }, {
+            type: 'gauge',
+            name: 'route.response_time',
+            value: ms,
+            localTags
+        }, {
+            type: 'timer',
+            name: 'route',
+            value: ms,
+            localTags
+        }];
+
         let stateTags = [];
+        let stateMetrics = [];
         if (request.plugins.dogstatsd) {
             stateTags = request.plugins.dogstatsd.tags;
+            stateMetrics = request.plugins.dogstatsd.metrics;
         }
 
-        Hoek.merge(tags, stateTags);
+        Hoek.merge(localTags, stateTags);
+        Hoek.merge(defaultMetrics, stateMetrics);
 
-        dogstatsdClient.incr('route.hits', null, tags);
-        dogstatsdClient.gauge('route.response_time', ms, tags);
-        dogstatsdClient.timer('route', ms, tags);
+        defaultMetrics.forEach((metric) => {
+            const { type, name, value, tags = [] } = metric;
+            dogstatsdClient[type](name, value, [...localTags, ...tags]);
+        });
 
         return h.continue;
     });


### PR DESCRIPTION
Adds support for passing custom metrics on a route response similar to how you can add extra tags specific to a route.

```js
request.plugins.dogstatsd.metrics = [{
    type: 'gauge',
    name: 'cache.orphans',
    value: 123,
    tags: [`cache_db:${cache}`]
}, {
    type: 'incr',
    name: 'cache.hit',
    value: null,
    tags: [`cache_db:${cache}`]
}]
```

This will result in the standard set of metrics to be sent to datadog in addition to the extra 2 metrics defined in the `plugins` space of the request/response.