### PR TITLE
fix(dupes): ML-1526 dedupelicate injected tags and metrics to avoid over reporting

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 const DogstatsdClient = require('dog-statsy');
 const Hoek = require('@hapi/hoek');
 const debug = require('debug')('hapi:plugins:dogstatsd');
-const { get, set } = require('lodash');
+const { get, set, uniq, uniqWith, isEqual } = require('lodash');
 
 const defaults = {
     dogstatsdClient: null,
@@ -45,13 +45,13 @@ const tagMap = {
 
 exports.injectMetricTags = ({ request, tags }) => {
     const ogTags = get(request, 'plugins.dogstatsd.tags', []);
-    set(request, 'plugins.dogstatsd.tags', [...ogTags, ...tags]);
+    set(request, 'plugins.dogstatsd.tags', uniq([...ogTags, ...tags]));
     return true;
 };
 
 exports.injectMetrics = ({ request, metrics }) => {
     const ogMetrics = get(request, 'plugins.dogstatsd.metrics', []);
-    set(request, 'plugins.dogstatsd.metrics', [...ogMetrics, ...metrics]);
+    set(request, 'plugins.dogstatsd.metrics', uniqWith([...ogMetrics, ...metrics], isEqual));
     return true;
 };
 

--- a/spec/helpers.spec.js
+++ b/spec/helpers.spec.js
@@ -40,9 +40,25 @@ describe('[helpers]', () => {
                 ...injectedTags
             ]));
         });
+
+        it('should deduplicate the tags list', () => {
+            // inject tags once
+            plugin.injectMetricTags({
+                request: this.requestMock,
+                tags: injectedTags
+            });
+            // inject tags again for some reason
+            plugin.injectMetricTags({
+                request: this.requestMock,
+                tags: injectedTags
+            });
+
+            expect(this.requestMock.plugins.dogstatsd).not.toBeUndefined();
+            expect(this.requestMock.plugins.dogstatsd.tags).toEqual(injectedTags);
+        });
     });
 
-    describe('pushMetrics', () => {
+    describe('injectMetrics', () => {
         const injectMetrics = [{
             type: 'gauge',
             name: 'cache.orphans',
@@ -90,6 +106,23 @@ describe('[helpers]', () => {
                 ...ogMetrics,
                 ...injectMetrics
             ]));
+        });
+
+        it('should deduplicate the tags list', () => {
+            // inject metrics once
+            plugin.injectMetrics({
+                request: this.requestMock,
+                metrics: injectMetrics
+            });
+
+            // inject metrics again for some reason
+            plugin.injectMetrics({
+                request: this.requestMock,
+                metrics: injectMetrics
+            });
+
+            expect(this.requestMock.plugins.dogstatsd).not.toBeUndefined();
+            expect(this.requestMock.plugins.dogstatsd.metrics).toEqual(injectMetrics);
         });
     });
 });


### PR DESCRIPTION
Noticed that `injectedTags` could be injected more than once. Checked `injectedMetrics` and saw the same issue.

```
  dog-statsy count "route.hits" 1 sample=null +8ms
  hapi:plugins:dogstatsd { type: 'gauge',
  hapi:plugins:dogstatsd   name: 'route.response_time',
  hapi:plugins:dogstatsd   value: 205,
  hapi:plugins:dogstatsd   tags:
  hapi:plugins:dogstatsd    [ 'url_path:/service-ml-data/v1/callouts/audio',
  hapi:plugins:dogstatsd      'status_code:200',
  hapi:plugins:dogstatsd      'http_method:POST',
  hapi:plugins:dogstatsd      'engine:postgres',
  hapi:plugins:dogstatsd      'engine:postgres',
  hapi:plugins:dogstatsd      'engine:postgres',
  hapi:plugins:dogstatsd      'isokta:true',
  hapi:plugins:dogstatsd      'user_email:dsmith@goodwaygroup.com',
  hapi:plugins:dogstatsd      'user_id:7' ] } +1ms
```

This will remove the duplicate `engine:postgres` tags